### PR TITLE
make slash command response in_channel

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ app.post('/', urlencodedParser, (req, res) => {
         } else {
           message.text = `${username} has created ${octoberPrs.length} PRs. ${PR_GOAL - octoberPrs.length} more to go!`;
         }
-
+        message.response_type = 'in_channel';
         if (verbose) {
           message.attachments = octoberPrs.map((pr) => {
             return {


### PR DESCRIPTION
Thanks for building this little bot! I wanted to add support for having the command be run in_channel so everyone can see it. I've followed the [slack slash commands](https://api.slack.com/slash-commands) api guide and included `response_type` of `in_channel` for the message response. During testing I kept getting the ephemeral message rather than the in_channel response. Any thoughts on what I'm doing wrong?
